### PR TITLE
Sanitize dataset ZIP entry names

### DIFF
--- a/tagpilot.html
+++ b/tagpilot.html
@@ -1139,6 +1139,30 @@ Limit the caption to ${maxWords} words or fewer.`;
             return ensureDatasetItemId({ file, tags, type });
         }
 
+        function isSafeDatasetFileName(filename) {
+            const name = String(filename || '');
+            return Boolean(name)
+                && name === name.split(/[\\/]/).pop()
+                && !name.includes('..')
+                && !/^[a-zA-Z]:/.test(name)
+                && !name.startsWith('/')
+                && !name.startsWith('\\');
+        }
+
+        function normalizeDatasetImageName(filename) {
+            if (!isSafeDatasetFileName(filename)) return null;
+            if (filename.toLowerCase().endsWith('.jpeg')) {
+                return filename.slice(0, -5) + '.jpg';
+            }
+            return filename;
+        }
+
+        function getDatasetTextFileName(imageName) {
+            const safeImageName = normalizeDatasetImageName(imageName);
+            if (!safeImageName) return null;
+            return safeImageName.replace(/\.[^/.]+$/, '.txt');
+        }
+
         function findDatasetItemIndexById(itemId) {
             return dataset.findIndex(item => item.id === itemId);
         }
@@ -1277,13 +1301,12 @@ Limit the caption to ${maxWords} words or fewer.`;
                 const imageExtensions = ['.jpg', '.jpeg', '.png', '.webp'];
 
                 for (const filename in zip.files) {
-                    if (zip.files[filename].dir) continue;
+                    if (zip.files[filename].dir || !isSafeDatasetFileName(filename)) continue;
                     const lowerFilename = filename.toLowerCase();
+                    const baseName = filename.substring(0, filename.lastIndexOf('.'));
                     if (imageExtensions.some(ext => lowerFilename.endsWith(ext))) {
-                        const baseName = filename.substring(0, filename.lastIndexOf('.'));
                         imageFiles[baseName] = { file: zip.files[filename], originalName: filename };
                     } else if (lowerFilename.endsWith('.txt')) {
-                        const baseName = filename.substring(0, filename.lastIndexOf('.'));
                         textFiles[baseName] = zip.files[filename];
                     }
                 }
@@ -1296,10 +1319,8 @@ Limit the caption to ${maxWords} words or fewer.`;
                     const { file: imageZipObject, originalName } = imageFiles[baseName];
                     const imageBlob = await imageZipObject.async('blob');
                     
-                    let finalName = originalName;
-                    if (originalName.toLowerCase().endsWith('.jpeg')) {
-                        finalName = originalName.slice(0, -5) + '.jpg';
-                    }
+                    const finalName = normalizeDatasetImageName(originalName);
+                    if (!finalName) continue;
                     const imageFile = new File([imageBlob], finalName, { type: imageBlob.type });
 
                     const hash = await calculateFileHash(imageFile);
@@ -1363,8 +1384,10 @@ Limit the caption to ${maxWords} words or fewer.`;
 
             const zip = new JSZip();
             dataset.forEach(item => {
-                zip.file(item.file.name, item.file);
-                const txtName = item.file.name.replace(/\.[^/.]+$/, ".txt");
+                const imageName = normalizeDatasetImageName(item.file.name);
+                const txtName = getDatasetTextFileName(imageName);
+                if (!imageName || !txtName) return;
+                zip.file(imageName, item.file);
                 zip.file(txtName, item.tags);
             });
             const blob = await zip.generateAsync({type:"blob"});

--- a/tests/prompt-settings.test.mjs
+++ b/tests/prompt-settings.test.mjs
@@ -202,6 +202,9 @@ globalThis.__tagpilotTest = {
     withTriggerWord,
     withoutTriggerWord,
     isBlankOrTriggerOnly,
+    isSafeDatasetFileName,
+    normalizeDatasetImageName,
+    getDatasetTextFileName,
     updateInputPrefixLabels: typeof updateInputPrefixLabels === 'function' ? updateInputPrefixLabels : null,
     setDataset(value) { dataset = value; ensureDatasetItemIds(); },
     getDataset() { return dataset; },
@@ -217,6 +220,30 @@ function deferred() {
     });
     return { promise, resolve };
 }
+
+
+test('dataset ZIP and export names reject path traversal components', async () => {
+    const { context } = await loadTagPilot();
+    const api = context.__tagpilotTest;
+
+    assert.equal(api.isSafeDatasetFileName('safe-image.jpg'), true);
+    assert.equal(api.normalizeDatasetImageName('safe-image.jpeg'), 'safe-image.jpg');
+    assert.equal(api.getDatasetTextFileName('safe-image.jpg'), 'safe-image.txt');
+
+    for (const unsafeName of [
+        '../outside.jpg',
+        '..\\..\\outside.jpg',
+        '/tmp/outside.jpg',
+        'C:\\tmp\\outside.jpg',
+        'nested/image.jpg',
+        '\\server\\share\\outside.jpg',
+        'almost..hidden.jpg',
+    ]) {
+        assert.equal(api.isSafeDatasetFileName(unsafeName), false, unsafeName);
+        assert.equal(api.normalizeDatasetImageName(unsafeName), null, unsafeName);
+        assert.equal(api.getDatasetTextFileName(unsafeName), null, unsafeName);
+    }
+});
 
 test('batch tagging sends the custom tag prompt to the selected provider', async () => {
     const { context, elements, fetchCalls } = await loadTagPilot();


### PR DESCRIPTION
### Motivation
- Imported ZIP entries were preserved verbatim and later written into exported archives, which allowed attacker-controlled paths (e.g. `..\\..\\outside.jpg`, absolute paths, drive-letter paths, or entries with slashes) to survive and create unsafe ZIP entry names on export.
- The change prevents downstream extractors or training workflows from writing files outside the intended extraction directory by ensuring exported names are safe, basenames only, and normalized.

### Description
- Added filename helper functions: `isSafeDatasetFileName(filename)` to validate that a name is a plain basename without path separators, traversal (`..`), drive letters, or absolute path prefixes; `normalizeDatasetImageName(filename)` to normalize `.jpeg` to `.jpg` and return `null` for unsafe names; and `getDatasetTextFileName(imageName)` to generate paired `.txt` names from validated image names.
- Updated ZIP import (`handleZipUpload`) to skip ZIP entries that fail `isSafeDatasetFileName` and to use `normalizeDatasetImageName` when constructing browser `File` objects so imported files have safe, normalized names.
- Updated ZIP export (`handleExport`) to derive export entry names via `normalizeDatasetImageName` and `getDatasetTextFileName`, skipping any items that do not produce safe names instead of writing `item.file.name` directly into the output ZIP.
- Added regression tests in `tests/prompt-settings.test.mjs` that exercise the safety helpers, `.jpeg`→`.jpg` normalization, paired `.txt` name generation, and several unsafe path variants to prevent regressions.

### Testing
- Ran the test suite with `node --test tests/prompt-settings.test.mjs`, which executed the new regression and the existing tests; all tests passed (`29` passing, `0` failing).
- Modified files: `tagpilot.html` and `tests/prompt-settings.test.mjs`, and validated the new import/export behavior through the unit tests described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a510dcc24ec832bb3c33d9f2daa5fc9)